### PR TITLE
Add <functional> header.

### DIFF
--- a/include/threadpool.h
+++ b/include/threadpool.h
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <functional>
 
 #include "config.h"
 


### PR DESCRIPTION
OS: Arch Linux 
CMake:  3.8.2
GCC:     7.1.1 20170528

Build fails if the \<functional\> header include is not present:
```
[ 28%] Building CXX object src/CMakeFiles/splash-0.7.dir/factory.cpp.o
In file included from /home/sergio/workspace/dev/others/splash/src/../include/././././././coretypes.h:45:0,
                 from /home/sergio/workspace/dev/others/splash/src/../include/./././././log.h:41,
                 from /home/sergio/workspace/dev/others/splash/src/../include/././././coretypes.h:41,
                 from /home/sergio/workspace/dev/others/splash/src/../include/./././attribute.h:35,
                 from /home/sergio/workspace/dev/others/splash/src/../include/././base_object.h:35,
                 from /home/sergio/workspace/dev/others/splash/src/../include/./buffer_object.h:35,
                 from /home/sergio/workspace/dev/others/splash/src/buffer_object.cpp:1:
/home/sergio/workspace/dev/others/splash/src/../include/./././././././threadpool.h:81:37: error: ‘function’ is not a member of ‘std’
     std::deque<std::shared_ptr<std::function<void()>>> tasks;
```