### PR TITLE
Fix -Wcatch-value from gcc8

### DIFF
--- a/src/core/link.cpp
+++ b/src/core/link.cpp
@@ -51,7 +51,7 @@ Link::~Link()
         _socketMessageOut->setsockopt(ZMQ_LINGER, &lingerValue, sizeof(lingerValue));
         _socketBufferOut->setsockopt(ZMQ_LINGER, &lingerValue, sizeof(lingerValue));
     }
-    catch (zmq::error_t e)
+    catch (zmq::error_t &e)
     {
         Log::get() << Log::ERROR << "Link::" << __FUNCTION__ << " - Error while closing socket: " << e.what() << Log::endl;
     }


### PR DESCRIPTION
Polymorphic class types should be caught by reference.

Signed-off-by: Pascal Huerst <pascal.huerst@gmail.com>